### PR TITLE
Add Permalink to each question

### DIFF
--- a/templates/footer.html
+++ b/templates/footer.html
@@ -60,7 +60,9 @@
         $(this).addClass('active');
       });
 
-      $('.show').collapse();
+      if($('.show').length !== 1 ) {
+        $('.show').collapse();
+      }
 
       // Coming from search result page click
       if(window.location.hash !== "") {

--- a/templates/macros/question.html
+++ b/templates/macros/question.html
@@ -7,6 +7,9 @@
   </h4>
   <div id="{{ item._id }}" class="collapse show anchor-spacer" role="tabpanel" data-parent="#{{ t_id }}Accordion">
     {{ item.description|safe }}
+    <div>
+      <a href="{{ item|url }}">Permalink</a>
+    </div>
   </div>
 </div>
 {% endmacro %}

--- a/templates/sidenav.html
+++ b/templates/sidenav.html
@@ -16,7 +16,7 @@
 	{% set topicbag = 'topics+' + this.alt %}
 	{% for id, item in bag(topicbag).items() %}
 	<li{% if this.is_child_of(item.path) %} class="nav-item" {% else %} class="toc-entry toc-h2 nav-item"{% endif %}>
-	  <a role="button" {% if this.is_child_of(item.path) %} class="side-nav active" {% else %} class="side-nav" {% endif %}  href="/{{ item.path }}">{{ item.label }}</a>
+	  <a role="button" {% if this.is_child_of(item.path) %} class="side-nav active" {% else %} class="side-nav" {% endif %}  href="{% if this.url_path != "/"%}/{% endif%}{{ item.path }}">{{ item.label }}</a>
 	</li>
 
 	{% endfor %}
@@ -31,7 +31,7 @@
       {% set topicbag = 'topics+' + this.alt %}
       {% for id, item in bag(topicbag).items() %}
       <li{% if this.is_child_of(item.path) %} class="toc-entry toc-h2 active nav-item" {% else %} class="toc-entry toc-h2 nav-item" {% endif %}>
-	<a role="button" {% if this.is_child_of(item.path) %} class="nav-link active" {% else %} class="nav-link" {% endif %}  href="/{{ item.path }}">{{ item.label }}</a>
+	<a role="button" {% if this.is_child_of(item.path) %} class="nav-link active" {% else %} class="nav-link" {% endif %}  href="{% if this.url_path != "/"%}/{% endif%}{{ item.path }}">{{ item.label }}</a>
       </li>
 
       {% endfor %}

--- a/templates/sidenav.html
+++ b/templates/sidenav.html
@@ -31,7 +31,7 @@
       {% set topicbag = 'topics+' + this.alt %}
       {% for id, item in bag(topicbag).items() %}
       <li{% if this.is_child_of(item.path) %} class="toc-entry toc-h2 active nav-item" {% else %} class="toc-entry toc-h2 nav-item" {% endif %}>
-	<a role="button" {% if this.is_child_of(item.path) %} class="nav-link active" {% else %} class="nav-link" {% endif %}  href="{{ item.path }}">{{ item.label }}</a>
+	<a role="button" {% if this.is_child_of(item.path) %} class="nav-link active" {% else %} class="nav-link" {% endif %}  href="/{{ item.path }}">{{ item.label }}</a>
       </li>
 
       {% endfor %}


### PR DESCRIPTION
This help with a lot of things:
- SEO in that DDG and others can find each underlaying page and rank them properly for the search term
- Users can easier link to a specific answer

The Bootstrap Collapse is disabled if there is only 1 question on the page as it does not make sense to collapse it then.