### PR TITLE
[FIX] Pre-fill title field when "Suggest Feedback" button is clicked

### DIFF
--- a/templates/macros/question.html
+++ b/templates/macros/question.html
@@ -12,7 +12,7 @@
          <!--li class="list-group-item"><a><span class="card-text text-muted">{{ _("Contributors to this page:") }} <a href="#" title="#">cypherpunk</a></span></li-->
          <li class="list-group-item">
            <a href="https://github.com/torproject/support/edit/master/content{{ item.path }}/contents.lr">{{ _("Edit this page") }}</a> -
-           <a href="https://github.com/torproject/support/issues/new?issue[assignee_id]=&issue[milestone_id]=&issue[title]=User feedback about {{ item.path }}">{{ _("Suggest Feedback") }}</a> -
+           <a href="https://github.com/torproject/support/issues/new?title=User feedback about {{ item.path }}">{{ _("Suggest Feedback") }}</a> -
            <a href="{{ item|url }}">{{ _("Permalink") }}</a>
           </li>
        </ul>


### PR DESCRIPTION
https://help.github.com/en/articles/about-automation-for-issues-and-pull-requests-with-query-parameters

Further, it would be neater to create an issue label for feedback so such issues can easily be differentiated. Plus a feedback template might be useful too, both of those can be used via query parameters while opening an issue.