### PR TITLE
Fix typographical error in content

### DIFF
--- a/content/tbb/tbb-45/contents.lr
+++ b/content/tbb/tbb-45/contents.lr
@@ -4,7 +4,7 @@ description:
 
 Sometimes, after you've used Gmail over Tor, Google presents a pop-up notification that your account may have been compromised. The notification window lists a series of IP addresses and locations throughout the world recently used to access your account.
 
-In general this is a false alarm: Google saw a bunch of logins from different places, as a result of running the service via Tor, and decided it was a good idea to confirm the account was being accessed by it's rightful owner.
+In general this is a false alarm: Google saw a bunch of logins from different places, as a result of running the service via Tor, and decided it was a good idea to confirm the account was being accessed by its rightful owner.
 
 Even though this may be a biproduct of using the service via tor, that doesn't mean you can entirely ignore the warning. It is probably a false positive, but it might not be since it is possible for someone to hijack your Google cookie.
 


### PR DESCRIPTION
it's → it is
its → shows possession

The latter is appropriate here.