### PR TITLE
Move signature verification result after the verification command

### DIFF
--- a/content/tbb/how-to-verify-signature/contents.lr
+++ b/content/tbb/how-to-verify-signature/contents.lr
@@ -67,13 +67,6 @@ To verify the signature of the package you downloaded, you will need to download
 
 The examples below assume that you downloaded these two files to your "Downloads" folder.
 
-The result of the command should produce something like this:
-
-    gpgv: Signature made 07/08/19 04:03:49 Pacific Daylight Time
-    gpgv:                using RSA key EB774491D9FF06E2
-    gpgv: Good signature from "Tor Browser Developers (signing key) <torbrowser@torproject.org>"
-
-
 #### For Windows users:
 
     gpgv --keyring .\tor.keyring Downloads\torbrowser-install-win64-8.5.5_en-US.exe.asc Downloads\torbrowser-install-win64-8.5.5_en-US.exe
@@ -86,6 +79,13 @@ The result of the command should produce something like this:
 
     gpgv --keyring ./tor.keyring ~/Downloads/tor-browser-linux64-8.5.5_en-US.tar.xz{.asc,}
 
+
+The result of the command should produce something like this:
+
+    gpgv: Signature made 07/08/19 04:03:49 Pacific Daylight Time
+    gpgv:                using RSA key EB774491D9FF06E2
+    gpgv: Good signature from "Tor Browser Developers (signing key) <torbrowser@torproject.org>"
+    
 
 You may also want to [learn more about GnuPG](https://www.gnupg.org/documentation/).
 


### PR DESCRIPTION
Maintains better readability flow.

relevant irc snippet 😛 
```
clash
one thing I noticed on the page is that the result of the command is given before the command itself which is a bit confusing

arma1
clash: hm, i don't think that's true?

clash
https://support.torproject.org/tbb/how-to-verify-signature/ Verifying The Signature heading

arma1
hm. yeah. it is right on the 'fetching' part, but on the 'verifying' part you're right it is weird.
```