### PR TITLE
Replaced  'at' to @

### DIFF
--- a/content/misc/bug-or-feedback/contents.lr
+++ b/content/misc/bug-or-feedback/contents.lr
@@ -24,7 +24,7 @@ You can file a ticket at [https://trac.torproject.org](https://trac.torproject.o
 
 #### Email
 
-Send us an email at frontdesk at torproject.org
+Send us an email to frontdesk@torproject.org
 
 In the subject line of your email, please tell us what you're reporting. The more objective your subject line is (e.g. "Connection failure", "feedback on website", "feedback on Tor Browser, "I need a bridge"), the easier it will be for us to understand and follow up. Sometimes when we receive emails without subject lines, they're marked as spam and we don't see them.
 


### PR DESCRIPTION
Changing the 'at' to @ , gives the reader more certainty on what email address to reach out to.