### PR TITLE
Validator errors in the template

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -1,10 +1,10 @@
 <!doctype html>
-<html xmlns="http://www.w3.org/1999/xhtml" {% if bag('alternatives', this.alt, 'direction') == 'text-right' %}dir="rtl"{% endif %}>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml" {% if bag('alternatives', this.alt, 'direction') == 'text-right' %}dir="rtl"{% endif %}>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="{{ _('Defend yourself against tracking and surveillance. Circumvent censorship.') }} | {{ this.title }}">
 <link rel="stylesheet" href="{{ '/static/css/bootstrap.css'|asseturl }}">
-<link rel="stylesheet" href="{{ '/static/fonts/fontawesome/css/all.min.css'|asseturl }}" rel="stylesheet">
+<link rel="stylesheet" href="{{ '/static/fonts/fontawesome/css/all.min.css'|asseturl }}">
 
 <title>{% block title %}{{ this.title }}{% endblock %} | {{ _("Tor Project | Support") }}</title>
 <body class="no-gutters" data-spy="scroll" data-target="#sidenav-topics" id="topics" data-children=".item">

--- a/templates/sidenav.html
+++ b/templates/sidenav.html
@@ -4,7 +4,7 @@
 	{{ _("Topics") }}
     </a>
     <label class="side-toggler" for="menu-toggle">
-      <a class="btn btn-lg outline-primary text-primary navbar-toggler chevron" data-toggle="collapse" data-target="#navbarSupportedTopicsContent" aria-controls="navbarSupportedTopicsContent" aria-expanded="false" aria-label="Toggle navigation">
+      <a class="btn btn-lg outline-primary text-primary navbar-toggler chevron" role="navbar chevron" data-toggle="collapse" data-target="#navbarSupportedTopicsContent" aria-controls="navbarSupportedTopicsContent" aria-expanded="false" aria-label="Toggle navigation">
     	<span class="oi oi-chevron-top chevron-up"></span>
     	<span class="oi oi-chevron-bottom chevron-down"></span>
       </a>


### PR DESCRIPTION
This is an attempt to fix[ this issue](https://dip.torproject.org/torproject/web/support/issues/71)
The continuation of this fix is at [this pull request](https://github.com/torproject/lego/pull/7).

@emmapeel2 @gusgustavo  As seen here, there are several [duplicate IDs](https://validator.w3.org/nu/?doc=https%3A%2F%2Fsupport.torproject.org%2F). These duplicate IDs do not show up in the code, and I think this is because lektor automatically atrributes them based on the contents.lr file. From what I noticed, if headers have identical text, they automatically get identical IDs. Am I wrong? Is there anything I can do about it?