### PR TITLE
update the link

### DIFF
--- a/content/about/how-is-tor-different-from-other-proxies/contents.lr
+++ b/content/about/how-is-tor-different-from-other-proxies/contents.lr
@@ -38,6 +38,6 @@ Possibly.
 A bad third of three servers can see the traffic you sent into Tor.
 It won't know who sent this traffic.
 If you're using encryption (like HTTPS), it will only know the destination.
-See this visualization of [Tor and HTTPS](/https/https-1/) to understand how Tor and HTTPS interact.
+See this visualization of [Tor and HTTPS](add new link here) to understand how Tor and HTTPS interact.
 ---
 _slug: how-is-tor-different-from-other-proxies


### PR DESCRIPTION
The link to visualize Tor and HTTPS gives the error- '404: This is not the web page you are looking for'. Update the broken link with the visualization to understand how Tor and HTTPS interact.