### PR TITLE
Fix the style

### DIFF
--- a/content/connecting/connecting-2/contents.lr
+++ b/content/connecting/connecting-2/contents.lr
@@ -10,7 +10,7 @@ If you’re having trouble connecting, please select the option to "copy Tor log
 Then paste the Tor log into a text file or other document.
 You should see one of these common log errors (look for the following lines in your Tor log):
 
-###### Common log error #1: Proxy connection failure
+##### Common log error #1: Proxy connection failure
 
     2017-10-29 09:23:40.800 [NOTICE] Opening Socks listener on 127.0.0.1:9150
     2017-10-29 09:23:47.900 [NOTICE] Bootstrapped 5%: Connecting to directory server


### PR DESCRIPTION
Fix the style issue for the header of log error 1 to look it like the other log error headers. Remove an extra # to make it look the same as other headers.