### PR TITLE
Enable HTML redirects

### DIFF
--- a/content/tbb/tbb-7
+++ b/content/tbb/tbb-7
@@ -1,1 +1,0 @@
-../censorship/censorship-2/

--- a/content/tbb/tbb-7/contents.lr
+++ b/content/tbb/tbb-7/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+target: ../../censorship/censorship-2/
+---
+_discoverable: no

--- a/models/redirect.ini
+++ b/models/redirect.ini
@@ -1,0 +1,1 @@
+../lego/models/redirect.ini

--- a/templates/macros/topic.html
+++ b/templates/macros/topic.html
@@ -9,8 +9,13 @@
   <div id="{{ t.control }}" role="tabpanel" data-parent="#topics" class="anchor-spacer">
     <div id="{{ t.control }}Accordion" data-children=".question">
       <h5 class="text-muted mb-3 p-0 {{ bag('alternatives', alternative, 'direction') }}">{{ item.title }}</h5>
-      {% for q in item.children.order_by('key') %}
-        {{ render_question(q, item._id, alternative) }}
+      {% for q in item.children.include_undiscoverable(true).order_by('key') %}
+        {% if q._model == 'redirect' %}
+          {% set r = site.get(q.target) %}
+          {{ render_question(r, item._id, alternative) }}
+        {% else %}
+          {{ render_question(q, item._id, alternative) }}
+        {% endif %}
       {% endfor %}
     </div>
   </div>

--- a/templates/redirect.html
+++ b/templates/redirect.html
@@ -1,0 +1,1 @@
+../lego/templates/redirect.html


### PR DESCRIPTION
This change enables the HTML redirect method from torproject/lego#5 to redirect questions inline. "Edit this page" and "Permalink" buttons also work! :tada: