### PR TITLE
Remove eoy.css link

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -4,7 +4,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="{{ _('Defend yourself against tracking and surveillance. Circumvent censorship.') }} | {{ this.title }}">
 <link rel="stylesheet" href="{{ '/static/css/bootstrap.css'|asseturl }}">
-<link rel="stylesheet" href="{{ '/static/css/eoy.css'|asseturl }}">
 <link rel="stylesheet" href="{{ '/static/fonts/fontawesome/css/all.min.css'|asseturl }}" rel="stylesheet">
 
 <title>{% block title %}{{ this.title }}{% endblock %} | {{ _("Tor Project | Support") }}</title>


### PR DESCRIPTION
Concerning the issue:

https://gitlab.torproject.org/torproject/web/support/-/issues/105

The line 

`<link rel="stylesheet" href="{{ '/static/css/eoy.css'|asseturl }}">`

has been removed.