### PR TITLE
Capitalize and make singular 'Tor rpm packages'

### DIFF
--- a/databags/topics.ini
+++ b/databags/topics.ini
@@ -61,7 +61,7 @@ label = Debian Repository
 [rpm]
 path = #rpm
 control = rpm
-label = Tor rpm packages
+label = Tor RPM Package
 
 [misc]
 path = #misc

--- a/databags/topics.ini
+++ b/databags/topics.ini
@@ -61,7 +61,7 @@ label = Debian Repository
 [rpm]
 path = #rpm
 control = rpm
-label = Tor RPM Package
+label = RPM Repository
 
 [misc]
 path = #misc


### PR DESCRIPTION
Concerning issue, https://gitlab.torproject.org/torproject/web/support/-/issues/110.

Fixed:

![fixed-tor-rpm-packages](https://user-images.githubusercontent.com/44947175/79884490-12b8c780-83aa-11ea-9198-a9d10352a09b.png)
