### PR TITLE
Route topic links to topic page and add RPM Repository

### DIFF
--- a/databags/topics.ini
+++ b/databags/topics.ini
@@ -1,89 +1,89 @@
 [faq]
-path = #faq
+path = faq
 control = faq
 label = Most Frequently Asked Questions
 
 [about]
-path = #about
+path = about
 control = about
 label = About Tor
 
 [tbb]
-path = #tbb
+path = tbb
 control = tbb
 label = Tor Browser
 
 [tormobile]
-path = #tormobile
+path = tormobile
 control = tormobile
 label = Tor Mobile
 
 [gettor]
-path = #gettor
+path = gettor
 control = gettor
 label = GetTor
 
 [connecting]
-path = #connectingtotor
+path = connecting
 control = connectingtotor
 label = Connecting To Tor
 
 [censorship]
-path = #censorship
+path = censorship
 control = censorship
 label = Censorship
 
 [https]
-path = #https
+path = https
 control = https
 label = HTTPS
 
 [operators]
-path = #operators
+path = operators
 control = operators
 label = Operators
 
 [onionservices]
-path = #onionservices
+path = onionservices
 control = onionservices
 label = Onion Services
 
 [metrics]
-path = #metrics
+path = metrics
 control = metrics
 label = Tor Metrics
 
 [apt]
-path = #apt
+path = apt
 control = apt
 label = Debian Repository
 
 [rpm]
-path = #rpm
+path = rpm
 control = rpm
-label = Tor rpm packages
+label = RPM Repository
 
 [misc]
-path = #misc
+path = misc
 control = misc
 label = Misc
 
 [abuse]
-path = #abuse
+path = abuse
 control = abuse
 label = Abuse FAQs
 
 [get-in-touch]
-path = #getintouch
+path = get-in-touch
 control = getintouch
 label = Get in Touch
 
 [glossary]
-path = /glossary
+path = glossary
 control = glossary
 label = Glossary
 
 [tormessenger]
-path = #tormessenger
+path = tormessenger
 control = tormessenger
 label = Tor Messenger


### PR DESCRIPTION
Regarding these issues:
* [Topics Links in Sidenav Should Link to Topic Page](https://gitlab.torproject.org/torproject/web/support/-/issues/109)
* ['Tor rpm packages' Needs to be Capitalized and Singular](https://gitlab.torproject.org/torproject/web/support/-/issues/110)
------
As requested:

* the commits were squashed into one commit from [Route topics links to topic page](https://github.com/torproject/support/pull/147)
* I combined this PR [Capitalize and make singular 'Tor rpm packages'](https://github.com/torproject/support/pull/148)
* I was also directed to push to master.
* All redundant RPs were directed to this updated one & closed