### PR TITLE
Link directly to #tor channel for support on OFTC ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The site is accessible at the following locations:
 - https://support.torproject.org/
 - http://4bflp2c4tnynnbes.onion/
 
-**This is not a direct support helpdesk** and questions should not be submitted through this site. Head over to ```#tor``` on [OFTC IRC](https://webchat.oftc.net/) instead.
+**This is not a direct support helpdesk** and questions should not be submitted through this site. Head over to ```#tor``` on [OFTC IRC](https://webchat.oftc.net/?channels=tor) instead.
 
 ## Reporting Bugs or Feedback
 Bugs and feedback tickets can be submitted to the [trac.](https://trac.torproject.org/projects/tor)

--- a/content/get-in-touch/irc-help/contents.lr
+++ b/content/get-in-touch/irc-help/contents.lr
@@ -6,7 +6,7 @@ description:
 
 Here is how you can get onto IRC and start to chat with Tor contributors in real time:
 
-1. Enter in [OFTC](https://webchat.oftc.net/) webchat.
+1. Enter in [OFTC](https://webchat.oftc.net/?channels=tor) webchat.
 
 2. Fill in the blanks: 
 


### PR DESCRIPTION
This is related to https://bugs.torproject.org/33431 which was allegedly
once fixed but seems to have regressed at some point.

People are still going to #oftc or mailing OFTC's support email address. I think it must be because of those appearing in OFTC's MOTD upon connecting to IRC without a channel preselected.

This preselects the #tor channel to help reduce the amount of confused people asking the wrong people for Tor help.