### PR TITLE
Updated gpg output on - How to verify Tor Browser signature

### DIFF
--- a/content/tbb/how-to-verify-signature/contents.lr
+++ b/content/tbb/how-to-verify-signature/contents.lr
@@ -54,10 +54,10 @@ This should show you something like:
     gpg: key 4E2C6E8793298290: public key "Tor Browser Developers (signing key) <torbrowser@torproject.org>" imported
     gpg: Total number processed: 1
     gpg:               imported: 1
-    pub   rsa4096 2014-12-15 [C] [expires: 2020-08-24]
+    pub   rsa4096 2014-12-15 [C] [expires: 2025-07-21]
           EF6E286DDA85EA2A4BA7DE684E2C6E8793298290
     uid           [ unknown] Tor Browser Developers (signing key) <torbrowser@torproject.org>
-    sub   rsa4096 2018-05-26 [S] [expires: 2020-09-12]
+    sub   rsa4096 2018-05-26 [S] [expires: 2020-12-19]
 
 If you get an error message, something has gone wrong and you cannot continue until you've figured out why this didn't work. You might be able to import the key using the **Workaround (using a public key)** section instead.
 


### PR DESCRIPTION
Updated gpg output on https://support.torproject.org/tbb/how-to-verify-signature/
Addressing this issue: https://gitlab.torproject.org/tpo/web/support/-/issues/123