### PR TITLE
capitalise 'tor'

### DIFF
--- a/content/metrics/user-or-clients/contents.lr
+++ b/content/metrics/user-or-clients/contents.lr
@@ -1,6 +1,6 @@
 _model: question
 ---
-title: Are these tor clients or users?  What if there's more than one user behind a tor client?
+title: Are these Tor clients or users?  What if there's more than one user behind a Tor client?
 ---
 key: 6
 ---

--- a/content/metrics/user-overcount/contents.lr
+++ b/content/metrics/user-overcount/contents.lr
@@ -1,6 +1,6 @@
 _model: question
 ---
-title: What if a user runs tor on a laptop and changes their IP address a few times per day? Don't you overcount that user?
+title: What if a user runs Tor on a laptop and changes their IP address a few times per day? Don't you overcount that user?
 ---
 key: 7
 ---


### PR DESCRIPTION
https://gitlab.torproject.org/tpo/web/support/-/issues/124

fixed instances of un-capitalised 'Tor' in FAQ