### PR TITLE
added info about why DuckDuckGo is safer

### DIFF
--- a/content/tbb/tbb-41/contents.lr
+++ b/content/tbb/tbb-41/contents.lr
@@ -8,3 +8,5 @@ description:
 With the release of Tor Browser 6.0.6, we switched to DuckDuckGo as the primary search engine.
 For a while now, Disconnect, which was formerly used in Tor Browser, has had no access to Google search results.
 Since Disconnect is more of a meta search engine, which allows users to choose between different search providers, it fell back to delivering Bing search results, which were basically unacceptable quality-wise.
+DuckDuckGo does not log, collect or share the user's personal information or their search history, and therefore is best positioned to protect your privacy. 
+Most other search engines store your searches along with other information such as the timestamp, your IP address, and your account information if you are logged in. 


### PR DESCRIPTION
issue: https://gitlab.torproject.org/tpo/web/community/-/issues/93

Added a few sentences explaining the privacy benefits of using DuckDuckGo as a search engine. 