### PR TITLE
Include the "Preferences" menu item Windows alternative in the instructions

### DIFF
--- a/content/connecting/connecting-2/contents.lr
+++ b/content/connecting/connecting-2/contents.lr
@@ -9,7 +9,7 @@ description:
 If you’re having trouble connecting, an error message may appear and you can select the option to "copy Tor log to clipboard".
 Then paste the Tor log into a text file or other document.
 
-Alternatively, if you don't see this option and you have Tor Browser open, you can navigate to the [hamburger menu ("≡")](../../glossary/hamburger-menu), then click on "Preferences", and finally on "Tor" in the side bar.
+Alternatively, if you don't see this option and you have Tor Browser open, you can navigate to the [hamburger menu ("≡")](../../glossary/hamburger-menu), then click on "Preferences" (or "Options" in Windows), and finally on "Tor" in the side bar.
 At the bottom of the page, next to the "View the Tor logs" text, click the button "View Logs...".
 
 You should see one of these common log errors (look for the following lines in your Tor log):


### PR DESCRIPTION
Issue: https://gitlab.torproject.org/tpo/web/support/-/issues/126
Make it easier for Windows users to follow the instructions and locate the "Options" menu item by adding the windows alternative for the menu item