### PR TITLE
Remove space before and after slash (/)

### DIFF
--- a/content/tbb/tbb-42/contents.lr
+++ b/content/tbb/tbb-42/contents.lr
@@ -9,4 +9,4 @@ key: 20
 description:
 Tor Browser is built using [Firefox ESR](https://www.mozilla.org/en-US/firefox/organizations/), so errors regarding Firefox may occur.
 Please be sure no other instance of Tor Browser is already running, and that you have extracted Tor Browser in a location that your user has the correct permissions for.
-If you are running an anti-virus, please see [My antivirus/malware protection is blocking me from accessing Tor Browser](https://support.torproject.org/#tbb-10), it is common for anti-virus / anti-malware software to cause this type of issue.
+If you are running an anti-virus, please see [My antivirus/malware protection is blocking me from accessing Tor Browser](https://support.torproject.org/#tbb-10), it is common for anti-virus/anti-malware software to cause this type of issue.


### PR DESCRIPTION
Issue - https://gitlab.torproject.org/tpo/web/support/-/issues/133
Space before or after a slash should be avoided, they can be used that way when quoting a poem in which case the slash indicates a line break. They should be removed since the slash is used to indicate the word "or" here.