### PR TITLE
[Connecting to Tor] Adding the command line option to view logs

### DIFF
--- a/content/connecting/connecting-2/contents.lr
+++ b/content/connecting/connecting-2/contents.lr
@@ -9,8 +9,16 @@ description:
 If you’re having trouble connecting, an error message may appear and you can select the option to "copy Tor log to clipboard".
 Then paste the Tor log into a text file or other document.
 
-Alternatively, if you don't see this option and you have Tor Browser open, you can navigate to the [hamburger menu ("≡")](../../glossary/hamburger-menu), then click on "Preferences", and finally on "Tor" in the side bar.
+If you don't see this option and you have Tor Browser open, you can navigate to the [hamburger menu ("≡")](../../glossary/hamburger-menu), then click on "Preferences", and finally on "Tor" in the side bar.
 At the bottom of the page, next to the "View the Tor logs" text, click the button "View Logs...".
+
+Alternatively, on GNU/Linux, to view the logs right in the terminal, navigate to the Tor Browser directory and launch the Tor Browser from the command line by running:
+
+`./start-tor-browser.desktop --verbose` 
+
+or to save the logs to a file *(default: tor-browser.log)*  
+
+`./start-tor-browser.desktop --log [file]`
 
 You should see one of these common log errors (look for the following lines in your Tor log):
 


### PR DESCRIPTION
This addresses this issue here : https://gitlab.torproject.org/tpo/web/support/-/issues/140
Adding the option of launching the Tor Browser in terminal, on GNU/Linux, and obtain the logs right in the terminal. Either with the `--verbose` flag or saving it to a file with the flag `--log [file]` 