### PR TITLE
[Glossary][exit]Correcting misspelt etc.

### DIFF
--- a/content/glossary/exit/contents.lr
+++ b/content/glossary/exit/contents.lr
@@ -4,7 +4,7 @@ term: exit
 ---
 definition:
 
-The last [relay](../relay) in the [Tor circuit](../circuit) which sends [traffic](../traffic) out onto the public Internet. The service you are connecting to (website, chat service, email provider, etc..) will see the [IP address](../ip-address) of the exit.
+The last [relay](../relay) in the [Tor circuit](../circuit) which sends [traffic](../traffic) out onto the public Internet. The service you are connecting to (website, chat service, email provider, etc.) will see the [IP address](../ip-address) of the exit.
 
 ---
 translation: 


### PR DESCRIPTION
This addresses the issue here: https://gitlab.torproject.org/tpo/web/support/-/issues/144
During the TorL10n Hackathon a translator spotted that *etc.* was misspelt in the [[Glossary][exit] page](https://support.torproject.org/glossary/#exit). The spelling is fixed with this PR.
Thanks!