### PR TITLE
Add search-engine to glossary list

### DIFF
--- a/content/glossary/search-engine/contents.lr
+++ b/content/glossary/search-engine/contents.lr
@@ -1,0 +1,12 @@
+_model: word
+---
+term: search engine
+---
+definition:
+
+A search engine is a web-based utility that assist users to explore information on the world wide web based on the data they provide. The search engine Tor Browser utilizes is [DuckDuckGo ](www.duckduckgo.com) because it doesn't track user data and it's anonymity reactive.
+
+---
+translation: 
+---
+spelling: 


### PR DESCRIPTION
The term search engine not present. I'll be important to add it since it's one of the core functions of Tor Browser.