### PR TITLE
Change DuckDuckGo's .onion domain to their v3 one

### DIFF
--- a/content/onionservices/onionservices-1/contents.lr
+++ b/content/onionservices/onionservices-1/contents.lr
@@ -6,6 +6,6 @@ seo_slug: accessing-websites-that-are-only-accessible-over-tor
 ---
 description:
 Websites that are only accessible over Tor are called "onions" and end in the TLD .onion.
-For example, the DuckDuckGo onion is [https://3g2upl4pq6kufc4m.onion](https://3g2upl4pq6kufc4m.onion).
+For example, the DuckDuckGo onion is [https://duckduckgogg42xjoc72x3sjasowoarfbgcmvfimaftt6twagswzczad.onion/](https://duckduckgogg42xjoc72x3sjasowoarfbgcmvfimaftt6twagswzczad.onion/).
 You can access these websites by using Tor Browser.
 The addresses must be shared with you by the website host, as onions are not indexed in search engines in the typical way that vanilla websites are.

--- a/content/onionservices/onionservices-3/contents.lr
+++ b/content/onionservices/onionservices-3/contents.lr
@@ -9,4 +9,4 @@ If you cannot reach the onion service you desire, make sure that you have entere
 If you are still unable to connect to the onion service, please try again later.
 There may be a temporary connection issue, or the site operators may have allowed it to go offline without warning.
 
-You can also ensure that you're able to access other onion services by connecting to [DuckDuckGo's onion service](http://3g2upl4pq6kufc4m.onion).
+You can also ensure that you're able to access other onion services by connecting to [DuckDuckGo's onion service](https://duckduckgogg42xjoc72x3sjasowoarfbgcmvfimaftt6twagswzczad.onion/).


### PR DESCRIPTION
This PR updates DuckDuckGo's `.onion` domain from their v2 one to their v3 one on the Onion Services support site.