### PR TITLE
Add moat to glossary

### DIFF
--- a/content/glossary/domain-fronting/contents.lr
+++ b/content/glossary/domain-fronting/contents.lr
@@ -5,7 +5,7 @@ term: domain fronting
 definition:
 
 Domain fronting is a censorship circumvention technique which masks the site you are connecting to.
-From the perspective of a censor, it makes it appear like you are connecting to a major service which would be costly for a censor to block, like Microsoft or Google.
+From the perspective of a censor, it appears like you are connecting to a major service which would be costly for a censor to block, like Microsoft or Google.
 However, it does not make you anonymous, or completely hide your destination like [Tor Browser](../tor-browser) does.
 ---
 translation:

--- a/content/glossary/domain-fronting/contents.lr
+++ b/content/glossary/domain-fronting/contents.lr
@@ -1,0 +1,13 @@
+_model: word
+---
+term: domain fronting
+---
+definition:
+
+Domain fronting is a censorship circumvention technique which masks the site you are connecting to.
+From the perspective of a censor, it makes it appear like you are connecting to a major service which would be costly for a censor to block, like Microsoft or Google.
+However, it does not make you anonymous, or completely hide your destination like [Tor Browser](../tor-browser) does.
+---
+translation:
+---
+spelling:

--- a/content/glossary/moat/contents.lr
+++ b/content/glossary/moat/contents.lr
@@ -4,13 +4,9 @@ term: moat
 ---
 definition:
 
-The interactive tool to get [bridges] from within [Tor Browser].
+The interactive tool to get [bridges](../bridge) from within [Tor Browser](../tor-browser).
 
-[Click here], to read more about using moat in the Tor Browser manual.
-
-[bridges]: ../bridge
-[Tor Browser]: ../tor-browser
-[Click here]: https://tb-manual.torproject.org/bridges/#using-moat
+[Click here](https://tb-manual.torproject.org/bridges/#using-moat), to read more about using moat in the Tor Browser manual.
 ---
 translation:
 ---

--- a/content/glossary/moat/contents.lr
+++ b/content/glossary/moat/contents.lr
@@ -5,7 +5,7 @@ term: moat
 definition:
 
 Moat is an interactive tool you can use to get [bridges](../bridge) from within [Tor Browser](../tor-browser).
-It uses domain fronting to help you circumvent censorship.
+It uses [domain fronting](../domain-fronting) to help you circumvent censorship.
 Moat also employs a [Captcha](../captcha) to prevent a censor from quickly blocking all of the bridges.
 
 [Click here](https://tb-manual.torproject.org/bridges/#using-moat), to read more about using moat in the Tor Browser manual.

--- a/content/glossary/moat/contents.lr
+++ b/content/glossary/moat/contents.lr
@@ -4,7 +4,9 @@ term: moat
 ---
 definition:
 
-The interactive tool to get [bridges](../bridge) from within [Tor Browser](../tor-browser).
+Moat is an interactive tool you can use to get [bridges](../bridge) from within [Tor Browser](../tor-browser).
+It uses domain fronting to help you circumvent censorship.
+Moat also employs a [Captcha](../captcha) to prevent a censor from quickly blocking all of the bridges.
 
 [Click here](https://tb-manual.torproject.org/bridges/#using-moat), to read more about using moat in the Tor Browser manual.
 ---

--- a/content/glossary/moat/contents.lr
+++ b/content/glossary/moat/contents.lr
@@ -1,0 +1,17 @@
+_model: word
+---
+term: moat
+---
+definition:
+
+The interactive tool to get [bridges] from within [Tor Browser].
+
+[Click here], to read more about using moat in the Tor Browser manual.
+
+[bridges]: ../bridge
+[Tor Browser]: ../tor-browser
+[Click here]: https://tb-manual.torproject.org/bridges/#using-moat
+---
+translation:
+---
+spelling:


### PR DESCRIPTION
Closes [support#243].

I also thought of including the entomology behind moat but didn't have much luck in mailing lists or web searches. The closest I found was that you need a bridge to get across a moat (via reddit). Maybe like moat protects the bridges from censors while allowing users to get across? If anyone knows where we could find the history, it might be cool to mention in here. :)

Please let me know of any other improvements you would like me to make!

[support#243]: https://gitlab.torproject.org/tpo/web/support/-/issues/243