### PR TITLE
Added button to expand all topics

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -9,7 +9,16 @@
 <link rel="icon" type="image/x-icon" href="{{ '/static/images/favicon.ico'|asseturl }}">
 <!-- Recommended favicon format -->
 <link rel="icon" type="image/png" href="{{ '/static/images/favicon.png'|asseturl }}">
-
+<script>
+  function change(event) {
+    let btn = event.currentTarget;
+    if (btn.innerHTML == {{ _('expand') }}) {
+      btn.innerHTML = {{ _('collapse') }};
+  } else {
+    btn.innerHTML = {{ _('expand') }};
+    }
+  }
+</script>
 
 <title>{% block title %}{{ this.title }} {{ this.term }} {% endblock %} | {{ _("Tor Project | Support") }}</title>
 <body class="no-gutters" data-spy="scroll" data-target="#sidenav-topics" id="topics" data-children=".item">
@@ -32,7 +41,8 @@
         {% include 'sidenav.html' %}
         {% set locale = bag('alternatives', this.alt) %}
         <main role="main" class="col-sm-12 col-xs-12  ml-sm-auto col-md-9 col-lg-9  {{ locale.order }} {{ locale.direction }}">
-          {% block body %}{% endblock %}
+        <button class="btn btn-primary float-right" data-toggle="collapse" data-target=".expand" aria-expanded="false" onclick="change(event)">expand</button>
+        {% block body %}{% endblock %}
         </main>
       </div>
     </div>

--- a/templates/macros/question.html
+++ b/templates/macros/question.html
@@ -5,7 +5,7 @@
       {{ item.title }}
     </a>
   </h4>
-  <div id="{{ q_id }}" class="collapse show anchor-spacer" role="tabpanel" data-parent="#{{ t_id }}Accordion">
+  <div id="{{ q_id }}" class="collapse show anchor-spacer expand" role="tabpanel">
     {{ item.description|safe }}
 
     {% if q_id == "https-1" %}

--- a/templates/macros/topic.html
+++ b/templates/macros/topic.html
@@ -7,7 +7,7 @@
     <a href="{{ t.path }}" role="button"></a>
   </h3>
   <div id="{{ t.control }}" role="tabpanel" data-parent="#topics" class="anchor-spacer">
-    <div id="{{ t.control }}Accordion" data-children=".question">
+    <div data-children=".question">
       <h5 class="text-muted mb-3 p-0 {{ bag('alternatives', alternative, 'direction') }}">{{ item.title }}</h5>
       {% for q in item.children.include_undiscoverable(true).order_by('key') %}
         {% if q._model == 'redirect' %}


### PR DESCRIPTION
Addressing the issue : https://gitlab.torproject.org/tpo/web/support/-/issues/113
 
A button to 'expand all topics', so people can easily search using their browser. Right now, you can do that by blocking all the JS.